### PR TITLE
Add '.' character to project name regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Dotnet Core Essentials Change Log
 
+## 0.0.3 - 2018-03-04
+
+- Allowed '.' in project names the same as the cli
+
 ## 0.0.3 - 2017-12-31
 
 ### Bug Fixes

--- a/src/DataSource.ts
+++ b/src/DataSource.ts
@@ -16,7 +16,9 @@ export class DataSource {
         ['ASP.NET Core with Angular', 'angular'],
         ['ASP.NET Core Web App with Razor', 'razor'],
         ['ASP.NET Core with React.js', 'react'],
-        ['ASP.NET Core with React.js and Redux', 'reactredux']
+        ['ASP.NET Core with React.js and Redux', 'reactredux'],
+        ['Unit Test Project', 'mstest'],
+        ['xUnit Test Project','xunit']
     ]);
     private static _referenceTypeList: string[] = ['Add Project Reference', 'Add Assembly Reference (.dll Reference)'];
     private static _validationList: string[] = ['con', 'aux', 'prn', 'com1', 'new', 'lpt2', '', ' ', null,'console','web'];

--- a/src/Utilities/ValidationUtility.ts
+++ b/src/Utilities/ValidationUtility.ts
@@ -14,7 +14,7 @@ import { DataSource } from '../DataSource';
 export class ValidationUtility {
 
     public static ValidateSlnAndProjectName(name: any): boolean {
-        return /^[a-zA-Z0-9_ ]*$/.test(name) && !(DataSource.GetValidationList().indexOf(name) > -1);
+        return /^[a-zA-Z0-9_. ]*$/.test(name) && !(DataSource.GetValidationList().indexOf(name) > -1);
     }
 
     // To check whether dotnet core 2.x sdk is installed.


### PR DESCRIPTION
When creating dotnet core applications with the cli it allows
the character '.' and this is very common practice with
most dotnet applications.

The '.' is now allowed in the regex for project names when
creating. The behaviour is consistent with the cli by allowing
the user to add a '.' at the beginning or end of the project name.